### PR TITLE
Add open in tab from the individual audiobooks page

### DIFF
--- a/addlink.js
+++ b/addlink.js
@@ -17,4 +17,15 @@ $(document).ready(function () {
         "' target='_blank'><button>Play in Tab</button></a>",
     )
   })
+
+  // Play in tab on the page of the book
+  $("button[name='playButton']").each(function () {
+    const asin = $(this).attr('asin')
+    const bookUrl = 'https://' + document.domain + '/webplayer?asin=' + asin
+    $(this).parent().after(
+      "<a href='" +
+        bookUrl +
+        "' target='_blank'><button>Play in Tab</button></a>",
+    )
+  })
 })

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Audible Play in Tab",
   "description": "Makes 'Play' button to open Audible cloudplayer in a tab instead of new window which gets lost and not easily accessible",
-  "version": "0.7",
+  "version": "0.71",
 
   "host_permissions": [
     "https://*.audible.com/*",


### PR DESCRIPTION
I am no frontender. So it can likely be improved. The .each is unnecessary for example.
But I tested the snippet from console and it works.

![image](https://github.com/hnprashanth/audible-play-in-tab/assets/742586/6280cffe-705d-413b-8a0e-09f92e76e103)
